### PR TITLE
[EDIFICE] Permettre à un utilisateur de voir ses blogs dans le playground

### DIFF
--- a/frontend/src/app/root/index.tsx
+++ b/frontend/src/app/root/index.tsx
@@ -10,6 +10,7 @@ import {
 import { Outlet } from "react-router-dom";
 
 import edifice from "../../assets/edifice.png";
+import BlogNavigator from "~/components/ent/BlogNavigator";
 
 function Root() {
   const { init } = useOdeClient();
@@ -40,6 +41,7 @@ function Root() {
           as="aside"
         >
           <Image ratio="1" alt="mon image" src={edifice} objectFit="contain" />
+          <BlogNavigator />
         </Grid.Col>
         <Grid.Col sm="4" md="8" lg="6" xl="9" className="py-16">
           <Outlet />

--- a/frontend/src/components/ent/BlogNavigator.tsx
+++ b/frontend/src/components/ent/BlogNavigator.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+
+export interface PostInformation {
+  id: string;
+  title: string;
+  blogTitle: string;
+}
+
+const BlogNavigator = () => {
+  const [loading, setLoading] = useState(false);
+  const [posts, setPosts] = useState<PostInformation[]>([]);
+
+  useEffect(() => {
+    async function inner() {
+      try {
+        const blogsResponse = await fetch(`/blog/list/all`);
+        if (blogsResponse.ok) {
+          const blogs = await blogsResponse.json();
+          const posts: PostInformation[] = blogs.flatMap((b: any) =>
+            (b.fetchPosts || []).map((post: any) => {
+              return {
+                id: post._id,
+                title: post.title,
+                blogTitle: b.title,
+              };
+            }),
+          );
+          setPosts(posts);
+        }
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    }
+    inner();
+  });
+
+  function renderLoading() {
+    return <div>Loading</div>;
+  }
+
+  function renderPost(post: PostInformation) {
+    return (
+      <li key={post.id}>
+        <a
+          href={`${window.location.origin}${window.location.pathname}?doc=${post.id}&source=blog`}
+        >
+          {post.blogTitle} - {post.title}
+        </a>
+      </li>
+    );
+  }
+
+  function renderPostLists() {
+    return <ul>{posts.map((p) => renderPost(p))}</ul>;
+  }
+
+  return loading ? renderLoading() : renderPostLists();
+};
+
+export default BlogNavigator;


### PR DESCRIPTION
# Description

Permettre à un utilisateur de voir ses blogs dans le playground.
Au chargement de la page, la liste intégrale des blogs des utilisateurs est récupérée et affichée à gauche de l'éditeur.
Lors d'un clic sur un nom de post, l'url de la page est modifiée pour lancer le chargement et l'affichage dudit poste dans l'éditeur

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
