### PR TITLE
fix: #WB-2024, add attribute download for image and video

### DIFF
--- a/frontend/src/components/Tiptap/AttachmentReact.tsx
+++ b/frontend/src/components/Tiptap/AttachmentReact.tsx
@@ -40,6 +40,8 @@ export const TestAttachment = (props: AttachmentProps) => {
     );
   };
 
+  console.log(node.attrs);
+
   return (
     attachmentArrayAttrs.length !== 0 && (
       <NodeViewWrapper>
@@ -58,14 +60,15 @@ export const TestAttachment = (props: AttachmentProps) => {
                   name={attachment.name}
                   options={
                     <>
-                      <IconButton
-                        aria-label={t("download")}
-                        color="tertiary"
-                        type="button"
-                        icon={<Download />}
-                        variant="ghost"
-                        onClick={() => window.open(attachment.href)}
-                      />
+                      <a href={attachment.href} download>
+                        <IconButton
+                          aria-label={t("download")}
+                          color="tertiary"
+                          type="button"
+                          icon={<Download />}
+                          variant="ghost"
+                        />
+                      </a>
                       <IconButton
                         aria-label={t("explorer.delete")}
                         color="danger"


### PR DESCRIPTION
# Description

Ajout d'une balise a pour l'attribut download et pouvoir télécharger direct la piece jointe

Ticket: #WB-2024
Lien : https://edifice-community.atlassian.net/browse/WB-2024
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

>

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
