### PR TITLE
Fix: toolbar pour liens externes et action associées

### DIFF
--- a/frontend/src/components/Tiptap/LinkToolbar.tsx
+++ b/frontend/src/components/Tiptap/LinkToolbar.tsx
@@ -5,7 +5,7 @@ import { Toolbar, ToolbarItem } from "@edifice-ui/react";
 import { FloatingMenu, FloatingMenuProps, Editor } from "@tiptap/react";
 import { useTranslation } from "react-i18next";
 
-interface LinkerToolbarProps {
+interface LinkToolbarProps {
   /**
    * editor instance
    */
@@ -18,63 +18,26 @@ interface LinkerToolbarProps {
   onUnlink: (attrs: any) => void;
 }
 
-const LinkerToolbar = ({
+const LinkToolbar = ({
   editor,
   onEdit,
   onOpen,
   onUnlink,
-}: LinkerToolbarProps) => {
+}: LinkToolbarProps) => {
   const { t } = useTranslation();
 
-  // Current Linker node attributes
-  const [linkerAttrs, setLinkerAttrs] = useState<
-    Record<string, any> | undefined
-  >();
+  // Current Linker node (or Hyperlink mark) attributes
+  const [linkAttrs, setLinkAttrs] = useState<Record<string, any> | undefined>();
 
-  const LinkerToolbarItems: ToolbarItem[] = useMemo(() => {
+  const LinkToolbarItems: ToolbarItem[] = useMemo(() => {
     return [
-      /* FIXME KISS or die
-      {
-        type: "dropdown",
-        name: "display",
-        props: {
-          children: (
-            <>
-              <Dropdown.Trigger
-                size="sm"
-                variant="ghost"
-                label={t("Affichage")}
-              />
-              <Dropdown.Menu>
-                <Dropdown.Item
-                  key="simple"
-                  onClick={() => handleDisplayChange("simple")}
-                >
-                  {t("Simplifié")}
-                </Dropdown.Item>
-                <Dropdown.Item
-                  key="url"
-                  onClick={() => handleDisplayChange("url")}
-                >
-                  {t("URL")}
-                </Dropdown.Item>
-              </Dropdown.Menu>
-            </>
-          ),
-        },
-      },
-      {
-        type: "divider",
-        name: "d0",
-      },
-      */
       {
         type: "icon",
         name: "edit",
         props: {
           icon: <Edit />,
           "aria-label": t("Modifier"),
-          onClick: () => onEdit?.(linkerAttrs),
+          onClick: () => onEdit?.(linkAttrs),
         },
       },
       {
@@ -83,7 +46,7 @@ const LinkerToolbar = ({
         props: {
           icon: <ExternalLink />,
           "aria-label": t("Ouvrir dans un nouvel onglet"),
-          onClick: () => onOpen?.(linkerAttrs),
+          onClick: () => onOpen?.(linkAttrs),
         },
       },
       {
@@ -92,17 +55,19 @@ const LinkerToolbar = ({
         props: {
           icon: <Unlink className="text-danger" />,
           "aria-label": t("Ouvrir dans un nouvel onglet"),
-          onClick: () => onUnlink?.(linkerAttrs),
+          onClick: () => onUnlink?.(linkAttrs),
         },
       },
     ];
-  }, [onEdit, onOpen, onUnlink, t, linkerAttrs]);
+  }, [onEdit, onOpen, onUnlink, t, linkAttrs]);
 
   // Retrieve any selected linker node ONLY WHEN EDITOR STRATE CHANGES
   useEffect(() => {
-    setLinkerAttrs(
-      editor?.isActive("linker") ? editor.getAttributes("linker") : undefined,
-    );
+    if (editor?.isActive("linker"))
+      setLinkAttrs(editor.getAttributes("linker"));
+    else if (editor?.isActive("hyperlink"))
+      setLinkAttrs(editor.getAttributes("hyperlink"));
+    else setLinkAttrs(undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor?.state]);
 
@@ -113,19 +78,22 @@ const LinkerToolbar = ({
     zIndex: 999,
   };
 
+  const handleShouldShow = () =>
+    editor?.isActive("linker") || editor?.isActive("hyperlink") || false;
+
   return (
     <>
       {editor && (
         <FloatingMenu
           editor={editor}
           tippyOptions={tippyOptions}
-          shouldShow={() => editor.isActive("linker")}
+          shouldShow={handleShouldShow}
         >
-          <Toolbar className="p-4" items={LinkerToolbarItems} />
+          <Toolbar className="p-4" items={LinkToolbarItems} />
         </FloatingMenu>
       )}
     </>
   );
 };
 
-export default LinkerToolbar;
+export default LinkToolbar;

--- a/frontend/src/components/Tiptap/Tiptap.tsx
+++ b/frontend/src/components/Tiptap/Tiptap.tsx
@@ -319,7 +319,12 @@ const Tiptap = () => {
 
         case "hyperlink": {
           const resourceTabResult = result as InternalLinkTabResult;
+          // Cancel any pre-selected link, see handleLinkEdit()
+          if (editor?.isActive("linker")) editor.commands.unsetLinker();
+          if (editor?.isActive("hyperlink"))
+            editor.commands.toggleMark("hyperlink");
 
+          // Manage new links
           editor?.commands.focus();
           if (
             editor.state.selection.empty &&
@@ -367,7 +372,7 @@ const Tiptap = () => {
 
               resourceTabResult.resources.forEach((link) => {
                 // Add a hyperlink to the selection.
-                editor?.commands.toggleLink({
+                editor?.commands.setLink({
                   href: link.path,
                   target: resourceTabResult.target ?? null,
                 });
@@ -476,6 +481,11 @@ const Tiptap = () => {
   };
 
   const handleLinkEdit = (attrs: LinkerAttributes | HyperlinkAttributes) => {
+    // If a link is active, select it.
+    if (editor?.isActive("linker")) editor.commands.selectParentNode();
+    if (editor?.isActive("hyperlink"))
+      editor.commands.extendMarkRange("hyperlink");
+
     const attrsLinker = attrs as LinkerAttributes;
     if (attrsLinker["data-id"] || attrsLinker["data-app-prefix"]) {
       mediaLibraryRef.current?.editLink({

--- a/frontend/src/components/Tiptap/Tiptap.tsx
+++ b/frontend/src/components/Tiptap/Tiptap.tsx
@@ -509,6 +509,7 @@ const Tiptap = () => {
 
   const handleLinkUnlink = (/*attrs: LinkerAttributes*/) => {
     editor?.commands.unsetLinker?.();
+    editor?.commands.unsetLink?.();
   };
 
   return (


### PR DESCRIPTION
# Description

Cette PR ajoute une barre d'outils edit/open/unlink aux liens externes, et supporte les règles de gestion suivantes : 

* Si on ajoute un lien interne sans avoir saisi de texte, on le met dans un badge.
* Si on ajoute un lien interne en ayant saisi du texte, on le met dans un lien hyeprtexte classique.
* On ne peut pas switcher d’un badge à un lien hypertexte classique.
* Si on ajoute un lien externe sans avoir saisi de texte, on affiche le lien cliquable. (on ne fait pas le système de récupération des metadata pour l’afficher dans un badge).
* Si on ajoute un lien externe en ayant saisi du texte, on applique le lien sur le texte.

PR associée : https://github.com/opendigitaleducation/edifice-ui/pull/71

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [X] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
