### PR TITLE
feat: copy HTML content to clipboard when read mode is activated

### DIFF
--- a/frontend/src/components/Tiptap/Playground.tsx
+++ b/frontend/src/components/Tiptap/Playground.tsx
@@ -123,6 +123,16 @@ const Playground = () => {
     }
   }, [fileId, docId, source]);
 
+  useEffect(() => {
+    if (mode === "read") {
+      // Copy content into clipboard
+      editorRef.current &&
+        navigator.clipboard.writeText(
+          editorRef.current.getContent("html") as string,
+        );
+    }
+  }, [mode]);
+
   return (
     <>
       <Toolbar


### PR DESCRIPTION
# Description

Editor's HTML content is automatically copied to clipboard when read-only mode is activated.

>

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
